### PR TITLE
Fix pyproject script entry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,11 @@ dev = [
 ]
 
 [project.scripts]
-ocrdlp = "cli:cli"
+ocrdlp = "ocrdlp:main"
+
+[tool.setuptools]
+py-modules = ["ocrdlp", "gpt4v_image_labeler", "gpt4v_analyzer"]
+packages = ["crawler"]
 
 [tool.ruff]
 target-version = "py311"


### PR DESCRIPTION
## Summary
- update the executable entry point to `ocrdlp:main`
- declare included modules so `pip install .` works

## Testing
- `python -m pip install .`
- `/root/.pyenv/versions/3.12.10/bin/ocrdlp --help`
- `pytest -q` *(fails: HTTPError 403 from serper.dev)*

------
https://chatgpt.com/codex/tasks/task_e_68411e273564833099bcb8ba3f7b90cc