### PR TITLE
Fix docs for CLI entry point

### DIFF
--- a/CRAWLER_MVP.md
+++ b/CRAWLER_MVP.md
@@ -11,7 +11,7 @@
 ## MVP Workflow
 ```bash
 # Complete dataset generation in one command
-python ocrdlp.py pipeline "invoice documents" --output-dir ./datasets/invoices --limit 100
+ocrdlp pipeline "invoice documents" --output-dir ./datasets/invoices --limit 100
 ```
 
 ## Generated Output

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ This is a **CRAWLER APPLICATION** that generates **LABELED DATASETS** for downst
    cd ocrdlp-lab
    ```
 
-2. **Install dependencies**
+2. **Install the package**
    ```bash
-   pip install -r requirements.txt
+   pip install -e .
    ```
 
 3. **Set environment variables**
@@ -53,7 +53,7 @@ This is a **CRAWLER APPLICATION** that generates **LABELED DATASETS** for downst
 ### Verify Installation
 
 ```bash
-python ocrdlp.py --help
+ocrdlp --help
 ```
 
 ## 📋 Dataset Generation Workflow
@@ -62,14 +62,14 @@ python ocrdlp.py --help
 
 ```bash
 # Search for document images
-python ocrdlp.py search "invoice documents" --engine serper --limit 100 --output urls.txt
+ocrdlp search "invoice documents" --engine serper --limit 100 --output urls.txt
 ```
 
 ### 2. Download Images
 
 ```bash
 # Download images to create dataset
-python ocrdlp.py download --urls-file urls.txt --output-dir ./datasets/raw_images
+ocrdlp download --urls-file urls.txt --output-dir ./datasets/raw_images
 ```
 
 ### 3. Generate Dataset with Labels
@@ -83,14 +83,14 @@ mkdir datasets/invoice_dataset/labels
 copy datasets/raw_images/*.* datasets/invoice_dataset/images/
 
 # Generate comprehensive labels
-python ocrdlp.py classify datasets/invoice_dataset/images --output datasets/invoice_dataset/labels/labels.jsonl
+ocrdlp classify datasets/invoice_dataset/images --output datasets/invoice_dataset/labels/labels.jsonl
 ```
 
 ### 4. Validate Dataset Quality
 
 ```bash
 # Validate generated dataset
-python ocrdlp.py validate datasets/invoice_dataset/labels/labels.jsonl
+ocrdlp validate datasets/invoice_dataset/labels/labels.jsonl
 ```
 
 ## 🏗️ Generated Dataset Structure
@@ -155,36 +155,36 @@ def load_dlp_dataset(dataset_path):
 
 ### Search Command
 ```bash
-python ocrdlp.py search "document type" --engine serper --limit 50 --output urls.txt
+ocrdlp search "document type" --engine serper --limit 50 --output urls.txt
 ```
 
 ### Download Command
 ```bash
-python ocrdlp.py download --urls-file urls.txt --output-dir ./images
+ocrdlp download --urls-file urls.txt --output-dir ./images
 # OR
-python ocrdlp.py download --query "invoice" --output-dir ./images --limit 20
+ocrdlp download --query "invoice" --output-dir ./images --limit 20
 ```
 
 ### Classify Command
 ```bash
-python ocrdlp.py classify ./images --output labels.jsonl --validate
+ocrdlp classify ./images --output labels.jsonl --validate
 ```
 
 ### Pipeline Command (Complete Workflow)
 ```bash
-python ocrdlp.py pipeline "invoice documents" --output-dir ./invoice_dataset --limit 50
+ocrdlp pipeline "invoice documents" --output-dir ./invoice_dataset --limit 50
 ```
 
 ### Validate Command
 ```bash
-python ocrdlp.py validate labels.jsonl
+ocrdlp validate labels.jsonl
 ```
 
 ## 🎉 Example: Creating Invoice Dataset
 
 ```bash
 # Complete workflow to create invoice training dataset
-python ocrdlp.py pipeline "invoice documents" --output-dir ./datasets/invoices --limit 100
+ocrdlp pipeline "invoice documents" --output-dir ./datasets/invoices --limit 100
 
 # Dataset is now ready at ./datasets/invoices/
 # - images/ contains downloaded invoice images

--- a/datasets/DATASET_GENERATION_WORKFLOW.md
+++ b/datasets/DATASET_GENERATION_WORKFLOW.md
@@ -8,10 +8,10 @@ This application is a **CRAWLER** that generates **LABELED DATASETS** for downst
 ### Step 1: Search & Download Images (Crawler Function)
 ```bash
 # Search for document images
-python ocrdlp.py search "invoice documents" --engine serper --limit 100 --output invoice_urls.txt
+ocrdlp search "invoice documents" --engine serper --limit 100 --output invoice_urls.txt
 
 # Download images to dataset
-python ocrdlp.py download --urls-file invoice_urls.txt --output-dir ./datasets/invoice_images
+ocrdlp download --urls-file invoice_urls.txt --output-dir ./datasets/invoice_images
 ```
 
 ### Step 2: Generate Labels (AI Labeling)
@@ -24,13 +24,13 @@ mkdir datasets/invoice_dataset/labels
 copy datasets/invoice_images/*.* datasets/invoice_dataset/images/
 
 # Generate comprehensive labels
-python ocrdlp.py classify datasets/invoice_dataset/images --output datasets/invoice_dataset/labels/labels.jsonl
+ocrdlp classify datasets/invoice_dataset/images --output datasets/invoice_dataset/labels/labels.jsonl
 ```
 
 ### Step 3: Package Dataset for Downstream Use
 ```bash
 # Validate dataset quality
-python ocrdlp.py validate datasets/invoice_dataset/labels/labels.jsonl
+ocrdlp validate datasets/invoice_dataset/labels/labels.jsonl
 
 # Dataset is now ready for model training
 ```

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -41,10 +41,10 @@ Use the crawler to generate new datasets:
 
 ```bash
 # Complete workflow
-python ocrdlp.py pipeline "document_type" --output-dir ./datasets/new_dataset --limit 100
+ocrdlp pipeline "document_type" --output-dir ./datasets/new_dataset --limit 100
 
 # Manual workflow
-python ocrdlp.py search "document_type" --limit 100 --output urls.txt
-python ocrdlp.py download --urls-file urls.txt --output-dir ./datasets/raw_images
-python ocrdlp.py classify ./datasets/raw_images --output ./datasets/new_dataset/labels.jsonl
+ocrdlp search "document_type" --limit 100 --output urls.txt
+ocrdlp download --urls-file urls.txt --output-dir ./datasets/raw_images
+ocrdlp classify ./datasets/raw_images --output ./datasets/new_dataset/labels.jsonl
 ``` 


### PR DESCRIPTION
## Summary
- update README instructions to install package via `pip install -e .`
- reference the `ocrdlp` command in all docs
- sync crawler docs with the current dataset commands

## Testing
- `pytest -q` *(fails: HTTPError 403 from serper)*

------
https://chatgpt.com/codex/tasks/task_e_68411e366c9883309739821f753399a3