### PR TITLE
Switch GPT4VAnalyzer to requests

### DIFF
--- a/gpt4v_analyzer.py
+++ b/gpt4v_analyzer.py
@@ -4,33 +4,31 @@ GPT-4V Invoice Analysis Script
 Analyzes invoice images and extracts structured tags.
 """
 
-import os
-import json
 import base64
-import asyncio
+import json
+import os
+import time
 from pathlib import Path
-from typing import Dict, List, Any
-import aiohttp
+from typing import Any
+
+import requests
 from PIL import Image
 
 
 class GPT4VAnalyzer:
     """GPT-4V image analyzer for invoice documents."""
-    
+
     def __init__(self, api_key: str):
         self.api_key = api_key
         self.base_url = "https://api.openai.com/v1/chat/completions"
-        self.headers = {
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {api_key}"
-        }
-    
+        self.headers = {"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"}
+
     def encode_image(self, image_path: str) -> str:
         """Encode image to base64."""
         with open(image_path, "rb") as image_file:
             return base64.b64encode(image_file.read()).decode('utf-8')
-    
-    def get_image_info(self, image_path: str) -> Dict[str, Any]:
+
+    def get_image_info(self, image_path: str) -> dict[str, Any]:
         """Get basic image information."""
         try:
             with Image.open(image_path) as img:
@@ -39,17 +37,17 @@ class GPT4VAnalyzer:
                     "height": img.height,
                     "format": img.format,
                     "mode": img.mode,
-                    "size_bytes": os.path.getsize(image_path)
+                    "size_bytes": os.path.getsize(image_path),
                 }
         except Exception as e:
             return {"error": str(e)}
-    
-    async def analyze_invoice(self, image_path: str) -> Dict[str, Any]:
+
+    def analyze_invoice(self, image_path: str) -> dict[str, Any]:
         """Analyze invoice image using GPT-4V."""
-        
+
         # 编码图像
         base64_image = self.encode_image(image_path)
-        
+
         # 构建提示词
         prompt = """
         请分析这张发票图像，提取以下结构化信息并以JSON格式返回：
@@ -96,7 +94,7 @@ class GPT4VAnalyzer:
         4. 置信度基于文本清晰度和完整性
         5. 只返回JSON，不要其他解释文字
         """
-        
+
         # 构建请求
         payload = {
             "model": "gpt-4o",
@@ -104,192 +102,201 @@ class GPT4VAnalyzer:
                 {
                     "role": "user",
                     "content": [
-                        {
-                            "type": "text",
-                            "text": prompt
-                        },
+                        {"type": "text", "text": prompt},
                         {
                             "type": "image_url",
                             "image_url": {
                                 "url": f"data:image/jpeg;base64,{base64_image}",
-                                "detail": "high"
-                            }
-                        }
-                    ]
+                                "detail": "high",
+                            },
+                        },
+                    ],
                 }
             ],
             "max_tokens": 2000,
-            "temperature": 0.1
+            "temperature": 0.1,
         }
-        
+
         # 发送请求
-        async with aiohttp.ClientSession() as session:
-            try:
-                async with session.post(
-                    self.base_url, 
-                    headers=self.headers, 
-                    json=payload,
-                    timeout=aiohttp.ClientTimeout(total=60)
-                ) as response:
-                    
-                    if response.status == 200:
-                        result = await response.json()
-                        
-                        # 提取GPT-4V的响应
-                        content = result['choices'][0]['message']['content']
-                        
-                        # 尝试解析JSON
-                        try:
-                            # 清理响应文本，提取JSON部分
-                            if '```json' in content:
-                                json_start = content.find('```json') + 7
-                                json_end = content.find('```', json_start)
-                                content = content[json_start:json_end].strip()
-                            elif '{' in content:
-                                json_start = content.find('{')
-                                json_end = content.rfind('}') + 1
-                                content = content[json_start:json_end]
-                            
-                            extracted_data = json.loads(content)
-                            
-                            # 添加元数据
-                            extracted_data['_metadata'] = {
-                                'image_path': image_path,
-                                'image_info': self.get_image_info(image_path),
-                                'analysis_timestamp': asyncio.get_event_loop().time(),
-                                'model_used': 'gpt-4o',
-                                'api_response_tokens': result.get('usage', {})
-                            }
-                            
-                            return extracted_data
-                            
-                        except json.JSONDecodeError as e:
-                            return {
-                                'error': 'JSON解析失败',
-                                'raw_response': content,
-                                'json_error': str(e),
-                                '_metadata': {
-                                    'image_path': image_path,
-                                    'image_info': self.get_image_info(image_path)
-                                }
-                            }
-                    else:
-                        error_text = await response.text()
-                        return {
-                            'error': f'API请求失败: {response.status}',
-                            'error_details': error_text,
-                            '_metadata': {
-                                'image_path': image_path,
-                                'image_info': self.get_image_info(image_path)
-                            }
-                        }
-                        
-            except Exception as e:
+        try:
+            response = requests.post(
+                self.base_url,
+                headers=self.headers,
+                json=payload,
+                timeout=60,
+            )
+
+            if response.status_code == 200:
+                result = response.json()
+
+                # 提取GPT-4V的响应
+                content = result['choices'][0]['message']['content']
+
+                # 尝试解析JSON
+                try:
+                    # 清理响应文本，提取JSON部分
+                    if '```json' in content:
+                        json_start = content.find('```json') + 7
+                        json_end = content.find('```', json_start)
+                        content = content[json_start:json_end].strip()
+                    elif '{' in content:
+                        json_start = content.find('{')
+                        json_end = content.rfind('}') + 1
+                        content = content[json_start:json_end]
+
+                    extracted_data = json.loads(content)
+
+                    # 添加元数据
+                    extracted_data['_metadata'] = {
+                        'image_path': image_path,
+                        'image_info': self.get_image_info(image_path),
+                        'analysis_timestamp': time.time(),
+                        'model_used': 'gpt-4o',
+                        'api_response_tokens': result.get('usage', {}),
+                    }
+
+                    return extracted_data
+
+                except json.JSONDecodeError as e:
+                    return {
+                        'error': 'JSON解析失败',
+                        'raw_response': content,
+                        'json_error': str(e),
+                        '_metadata': {
+                            'image_path': image_path,
+                            'image_info': self.get_image_info(image_path),
+                        },
+                    }
+            else:
                 return {
-                    'error': f'请求异常: {str(e)}',
+                    'error': f'API请求失败: {response.status_code}',
+                    'error_details': response.text,
                     '_metadata': {
                         'image_path': image_path,
-                        'image_info': self.get_image_info(image_path)
-                    }
+                        'image_info': self.get_image_info(image_path),
+                    },
                 }
 
+        except Exception as e:
+            return {
+                'error': f'请求异常: {str(e)}',
+                '_metadata': {
+                    'image_path': image_path,
+                    'image_info': self.get_image_info(image_path),
+                },
+            }
 
-async def analyze_invoice_images(image_dir: str, output_file: str = "tags.jsonl"):
+
+def analyze_invoice_images(image_dir: str, output_file: str = "tags.jsonl"):
     """分析发票图像并保存结果到JSONL文件."""
-    
+
     # 检查OpenAI API密钥
     api_key = os.getenv('OPENAI_API_KEY')
     if not api_key:
         print("❌ OPENAI_API_KEY not found!")
         return
-    
+
     analyzer = GPT4VAnalyzer(api_key)
-    
+
     # 查找图像文件
     image_dir = Path(image_dir)
     image_files = []
     for ext in ['*.jpg', '*.jpeg', '*.png', '*.webp']:
         image_files.extend(image_dir.glob(ext))
-    
+
     if not image_files:
         print(f"❌ No image files found in {image_dir}")
         return
-    
+
     print(f"🔍 Found {len(image_files)} images to analyze")
-    
+
     # 分析每张图像
     results = []
     for i, image_path in enumerate(image_files, 1):
         print(f"\n📊 Analyzing image {i}/{len(image_files)}: {image_path.name}")
-        
+
         try:
-            result = await analyzer.analyze_invoice(str(image_path))
+            result = analyzer.analyze_invoice(str(image_path))
             results.append(result)
-            
+
             # 显示结果摘要
             if 'error' not in result:
                 print(f"  ✅ 文档类型: {result.get('document_type', 'N/A')}")
-                print(f"  💰 总金额: {result.get('total_amount', 'N/A')} {result.get('currency', 'N/A')}")
+                print(
+                    f"  💰 总金额: {result.get('total_amount', 'N/A')} {result.get('currency', 'N/A')}"
+                )
                 print(f"  🏢 供应商: {result.get('vendor_name', 'N/A')}")
                 print(f"  🌐 语言: {result.get('language', 'N/A')}")
                 print(f"  📊 置信度: {result.get('confidence_score', 'N/A')}")
             else:
                 print(f"  ❌ 分析失败: {result.get('error', 'Unknown error')}")
-                
+
         except Exception as e:
             error_result = {
                 'error': f'处理异常: {str(e)}',
                 '_metadata': {
                     'image_path': str(image_path),
-                    'image_info': analyzer.get_image_info(str(image_path))
-                }
+                    'image_info': analyzer.get_image_info(str(image_path)),
+                },
             }
             results.append(error_result)
             print(f"  ❌ 处理异常: {e}")
-    
+
     # 保存到JSONL文件
     output_path = Path(output_file)
     with open(output_path, 'w', encoding='utf-8') as f:
         for result in results:
             f.write(json.dumps(result, ensure_ascii=False, indent=None) + '\n')
-    
+
     print(f"\n💾 Results saved to: {output_path}")
     print(f"📊 Total analyzed: {len(results)} images")
-    
+
     # 统计成功率
     successful = sum(1 for r in results if 'error' not in r)
     print(f"✅ Successful: {successful}/{len(results)} ({successful/len(results)*100:.1f}%)")
-    
+
     return results
 
 
 def validate_extracted_fields(jsonl_file: str = "tags.jsonl"):
     """验证提取的字段是否齐全."""
-    
+
     print(f"\n🔍 Validating extracted fields from {jsonl_file}")
-    
+
     required_fields = [
-        'document_type', 'language', 'currency', 'total_amount',
-        'vendor_name', 'invoice_number', 'invoice_date'
+        'document_type',
+        'language',
+        'currency',
+        'total_amount',
+        'vendor_name',
+        'invoice_number',
+        'invoice_date',
     ]
-    
+
     optional_fields = [
-        'tax_amount', 'customer_name', 'items', 'tax_details',
-        'addresses', 'payment_terms', 'confidence_score'
+        'tax_amount',
+        'customer_name',
+        'items',
+        'tax_details',
+        'addresses',
+        'payment_terms',
+        'confidence_score',
     ]
-    
+
     try:
-        with open(jsonl_file, 'r', encoding='utf-8') as f:
+        with open(jsonl_file, encoding='utf-8') as f:
             for i, line in enumerate(f, 1):
                 try:
                     data = json.loads(line.strip())
-                    
+
                     if 'error' in data:
                         print(f"  Record {i}: ❌ Analysis failed - {data['error']}")
                         continue
-                    
-                    print(f"\n  📄 Record {i} ({data.get('_metadata', {}).get('image_path', 'unknown')}):")
-                    
+
+                    print(
+                        f"\n  📄 Record {i} ({data.get('_metadata', {}).get('image_path', 'unknown')}):"
+                    )
+
                     # 检查必需字段
                     missing_required = []
                     present_required = []
@@ -298,59 +305,63 @@ def validate_extracted_fields(jsonl_file: str = "tags.jsonl"):
                             present_required.append(field)
                         else:
                             missing_required.append(field)
-                    
+
                     # 检查可选字段
                     present_optional = []
                     for field in optional_fields:
                         if field in data and data[field] is not None:
                             present_optional.append(field)
-                    
-                    print(f"    ✅ Required fields present: {len(present_required)}/{len(required_fields)}")
-                    print(f"    📋 Optional fields present: {len(present_optional)}/{len(optional_fields)}")
-                    
+
+                    print(
+                        f"    ✅ Required fields present: {len(present_required)}/{len(required_fields)}"
+                    )
+                    print(
+                        f"    📋 Optional fields present: {len(present_optional)}/{len(optional_fields)}"
+                    )
+
                     if missing_required:
                         print(f"    ❌ Missing required: {', '.join(missing_required)}")
-                    
+
                     # 显示关键信息
                     key_info = {
                         '文档类型': data.get('document_type'),
                         '语言': data.get('language'),
                         '货币': data.get('currency'),
                         '总金额': data.get('total_amount'),
-                        '置信度': data.get('confidence_score')
+                        '置信度': data.get('confidence_score'),
                     }
-                    
+
                     for key, value in key_info.items():
                         if value is not None:
                             print(f"    📊 {key}: {value}")
-                    
+
                 except json.JSONDecodeError as e:
                     print(f"  Record {i}: ❌ JSON parsing error - {e}")
-                    
+
     except FileNotFoundError:
         print(f"❌ File not found: {jsonl_file}")
 
 
 if __name__ == "__main__":
     import sys
-    
+
     # 设置图像目录
     image_dir = "invoice_images"
     if len(sys.argv) > 1:
         image_dir = sys.argv[1]
-    
+
     # 检查API密钥
     if not os.getenv('OPENAI_API_KEY'):
         print("❌ Please set OPENAI_API_KEY environment variable")
         print("Example: $env:OPENAI_API_KEY='your-api-key-here'")
         exit(1)
-    
+
     # 运行分析
     print("🚀 Starting GPT-4V Invoice Analysis")
-    results = asyncio.run(analyze_invoice_images(image_dir))
-    
+    results = analyze_invoice_images(image_dir)
+
     # 验证字段
     if results:
         validate_extracted_fields()
-    
-    print("\n🎉 Analysis completed!") 
+
+    print("\n🎉 Analysis completed!")

--- a/tests/test_integration_complete.py
+++ b/tests/test_integration_complete.py
@@ -4,25 +4,25 @@ Pytest兼容的模块集成测试
 测试图像搜索模块（Serper）和图像打标签模块（GPT-4V）的完整流程
 """
 
-import os
-import json
 import asyncio
-import tempfile
+import json
+import os
 import shutil
+import tempfile
 from pathlib import Path
-from typing import Dict, List, Any, Optional
+from typing import Any
+
 import pytest
 from PIL import Image
-import aiohttp
 
 # 导入现有模块
-from crawler.search import search_images, download_images
+from crawler.search import download_images, search_images
 from gpt4v_analyzer import GPT4VAnalyzer
 
 
 class TestIntegrationWorkflow:
     """集成测试类"""
-    
+
     @pytest.fixture(scope="class")
     def temp_dir(self):
         """创建临时目录"""
@@ -31,81 +31,78 @@ class TestIntegrationWorkflow:
         # 清理
         if temp_path.exists():
             shutil.rmtree(temp_path)
-    
+
     @pytest.fixture(scope="class")
     def api_keys(self):
         """检查API密钥"""
         serper_key = os.getenv('SERPER_API_KEY')
         openai_key = os.getenv('OPENAI_API_KEY')
-        
+
         if not serper_key:
             pytest.skip("SERPER_API_KEY not found in environment")
         if not openai_key:
             pytest.skip("OPENAI_API_KEY not found in environment")
-        
-        return {
-            'serper': serper_key,
-            'openai': openai_key
-        }
-    
+
+        return {'serper': serper_key, 'openai': openai_key}
+
     @pytest.mark.asyncio
     async def test_image_search_functionality(self, api_keys):
         """测试图像搜索功能"""
         query = "indian invoice blurry photo"
         limit = 5
-        
+
         # 调用图像搜索
         urls = await search_images(query, engine='serper', limit=limit)
-        
+
         # 验证结果
         assert isinstance(urls, list), "URLs should be a list"
         assert len(urls) > 0, "Should return at least one URL"
         assert len(urls) <= limit, f"Should not exceed limit of {limit}"
-        
+
         # 验证URL格式
         for url in urls:
             assert isinstance(url, str), "Each URL should be a string"
             assert url.startswith(('http://', 'https://')), f"Invalid URL format: {url}"
-        
+
         print(f"✅ Found {len(urls)} image URLs")
         return urls
-    
+
     @pytest.mark.asyncio
     async def test_image_download_functionality(self, temp_dir, api_keys):
         """测试图像下载功能"""
         # 先搜索图像
         urls = await search_images("indian invoice blurry photo", engine='serper', limit=3)
         assert len(urls) > 0, "Need at least one URL for download test"
-        
+
         # 下载第一张图像
         target_url = urls[0]
         results = await download_images([target_url], output_dir=str(temp_dir))
-        
+
         # 验证下载结果
         assert len(results) > 0, "Should download at least one image"
-        
+
         downloaded_path = list(results.values())[0]
         downloaded_file = Path(downloaded_path)
-        
+
         # 验证文件存在
         assert downloaded_file.exists(), f"Downloaded file should exist: {downloaded_path}"
-        
+
         # 验证文件大小
         file_size = downloaded_file.stat().st_size
         assert file_size > 1000, f"File too small ({file_size} bytes), might be corrupted"
-        
+
         # 验证是否为有效图像
         with Image.open(downloaded_file) as img:
             width, height = img.size
             format_type = img.format
-            
+
         # 验证图像尺寸合理
         assert width > 50 and height > 50, f"Image too small: {width}x{height}"
         assert width < 10000 and height < 10000, f"Image too large: {width}x{height}"
-        
+
         print(f"✅ Downloaded valid image: {width}x{height} {format_type}")
         return downloaded_path
-    
+
     @pytest.mark.asyncio
     async def test_gpt4v_analysis_functionality(self, temp_dir, api_keys):
         """测试GPT-4V分析功能"""
@@ -113,94 +110,103 @@ class TestIntegrationWorkflow:
         urls = await search_images("indian invoice blurry photo", engine='serper', limit=1)
         results = await download_images(urls[:1], output_dir=str(temp_dir))
         image_path = list(results.values())[0]
-        
+
         # 初始化分析器
         analyzer = GPT4VAnalyzer(api_keys['openai'])
-        
+
         # 分析图像
-        result = await analyzer.analyze_invoice(image_path)
-        
+        result = analyzer.analyze_invoice(image_path)
+
         # 验证分析结果
         assert isinstance(result, dict), "Result should be a dictionary"
-        
+
         # 如果有API错误，创建模拟结果进行验证
         if 'error' in result:
             if 'quota' in result['error'].lower() or '429' in str(result.get('error_details', '')):
                 result = self._create_mock_result(image_path)
             else:
                 pytest.fail(f"Analysis failed: {result['error']}")
-        
+
         # 验证必需字段
         required_fields = [
-            'document_type', 'language', 'currency', 'total_amount',
-            'vendor_name', 'invoice_number', 'invoice_date'
+            'document_type',
+            'language',
+            'currency',
+            'total_amount',
+            'vendor_name',
+            'invoice_number',
+            'invoice_date',
         ]
-        
+
         for field in required_fields:
             assert field in result, f"Missing required field: {field}"
             assert result[field] is not None, f"Required field {field} is None"
-        
+
         # 验证数据类型
-        assert isinstance(result['total_amount'], (int, float)), "total_amount should be numeric"
-        
+        assert isinstance(result['total_amount'], int | float), "total_amount should be numeric"
+
         if 'confidence_score' in result and result['confidence_score'] is not None:
             score = result['confidence_score']
             assert 0 <= score <= 1, f"Confidence score out of range: {score}"
-        
-        print(f"✅ Analysis completed: {result.get('document_type')} - {result.get('total_amount')} {result.get('currency')}")
+
+        print(
+            f"✅ Analysis completed: {result.get('document_type')} - {result.get('total_amount')} {result.get('currency')}"
+        )
         return result
-    
+
     @pytest.mark.asyncio
     async def test_end_to_end_workflow(self, temp_dir, api_keys):
         """测试完整的端到端工作流程"""
         query = "indian invoice blurry photo"
-        
+
         # 步骤1: 搜索图像
         print("Step 1: Searching images...")
         urls = await search_images(query, engine='serper', limit=3)
         assert len(urls) > 0, "Should find at least one image URL"
-        
+
         # 步骤2: 下载图像
         print("Step 2: Downloading image...")
         results = await download_images(urls[:1], output_dir=str(temp_dir))
         assert len(results) > 0, "Should download at least one image"
         image_path = list(results.values())[0]
-        
+
         # 步骤3: 分析图像
         print("Step 3: Analyzing image...")
         analyzer = GPT4VAnalyzer(api_keys['openai'])
-        analysis_result = await analyzer.analyze_invoice(image_path)
-        
+        analysis_result = analyzer.analyze_invoice(image_path)
+
         # 处理API限制
         if 'error' in analysis_result:
-            if 'quota' in analysis_result['error'].lower() or '429' in str(analysis_result.get('error_details', '')):
+            if 'quota' in analysis_result['error'].lower() or '429' in str(
+                analysis_result.get('error_details', '')
+            ):
                 analysis_result = self._create_mock_result(image_path)
-        
+
         # 步骤4: 保存结果
         output_file = temp_dir / "end_to_end_result.jsonl"
         with open(output_file, 'w', encoding='utf-8') as f:
             f.write(json.dumps(analysis_result, ensure_ascii=False, indent=None) + '\n')
-        
+
         # 验证最终结果
         assert output_file.exists(), "Output file should be created"
         assert output_file.stat().st_size > 100, "Output file should not be empty"
-        
+
         # 验证JSON格式
-        with open(output_file, 'r', encoding='utf-8') as f:
+        with open(output_file, encoding='utf-8') as f:
             loaded_result = json.loads(f.read().strip())
             assert loaded_result == analysis_result, "Saved and loaded results should match"
-        
-        print(f"✅ End-to-end workflow completed successfully!")
+
+        print("✅ End-to-end workflow completed successfully!")
         print(f"📁 Result saved to: {output_file}")
-        
+
         return {
             'urls_found': len(urls),
             'image_downloaded': image_path,
             'analysis_result': analysis_result,
-            'output_file': str(output_file)
+            'output_file': str(output_file),
         }
-    
-    def _create_mock_result(self, image_path: str) -> Dict[str, Any]:
+
+    def _create_mock_result(self, image_path: str) -> dict[str, Any]:
         """创建模拟分析结果（用于API配额限制时）"""
         return {
             "document_type": "Invoice",
@@ -217,7 +223,7 @@ class TestIntegrationWorkflow:
                     "description": "Test Services",
                     "quantity": "1",
                     "unit_price": 10250.00,
-                    "amount": 10250.00
+                    "amount": 10250.00,
                 }
             ],
             "tax_details": {
@@ -225,11 +231,11 @@ class TestIntegrationWorkflow:
                 "tax_rate": "18%",
                 "cgst": 1125.00,
                 "sgst": 1125.00,
-                "igst": None
+                "igst": None,
             },
             "addresses": {
                 "vendor_address": "Test Address, Test City 123456",
-                "customer_address": "Customer Address, Customer City 654321"
+                "customer_address": "Customer Address, Customer City 654321",
             },
             "payment_terms": "Net 30 days",
             "confidence_score": 0.85,
@@ -239,8 +245,8 @@ class TestIntegrationWorkflow:
                 "image_path": image_path,
                 "analysis_timestamp": asyncio.get_event_loop().time(),
                 "model_used": "gpt-4o",
-                "note": "Mock result due to API quota limits"
-            }
+                "note": "Mock result due to API quota limits",
+            },
         }
 
 
@@ -251,30 +257,30 @@ async def test_quick_integration():
     # 检查环境变量
     if not os.getenv('SERPER_API_KEY') or not os.getenv('OPENAI_API_KEY'):
         pytest.skip("API keys not available")
-    
+
     # 创建临时目录
     temp_dir = Path(tempfile.mkdtemp(prefix="quick_test_"))
-    
+
     try:
         # 搜索 -> 下载 -> 分析
         urls = await search_images("indian invoice", engine='serper', limit=1)
         assert len(urls) > 0
-        
+
         results = await download_images(urls[:1], output_dir=str(temp_dir))
         assert len(results) > 0
-        
+
         image_path = list(results.values())[0]
         analyzer = GPT4VAnalyzer(os.getenv('OPENAI_API_KEY'))
-        analysis = await analyzer.analyze_invoice(image_path)
-        
+        analysis = analyzer.analyze_invoice(image_path)
+
         # 基本验证
         assert isinstance(analysis, dict)
         if 'error' not in analysis:
             assert 'document_type' in analysis
             assert 'total_amount' in analysis
-        
+
         print("✅ Quick integration test passed!")
-        
+
     finally:
         # 清理
         if temp_dir.exists():
@@ -283,4 +289,4 @@ async def test_quick_integration():
 
 if __name__ == "__main__":
     # 直接运行测试
-    pytest.main([__file__, "-v", "-s"]) 
+    pytest.main([__file__, "-v", "-s"])

--- a/tests/test_serper_integration.py
+++ b/tests/test_serper_integration.py
@@ -2,226 +2,218 @@
 Tests for Serper.dev API integration.
 """
 
-import pytest
 import asyncio
-import os
-import tempfile
-import shutil
-from pathlib import Path
-from unittest.mock import Mock, patch, AsyncMock, MagicMock
-from PIL import Image
 import io
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from crawler.search import search_images, download_images, ImageSearchEngine
+import pytest
+from PIL import Image
+
+from crawler.search import download_images, search_images
 
 
 class TestSerperIntegration:
     """Test cases for Serper.dev API integration."""
-    
+
     @pytest.fixture
     def temp_dir(self):
         """Create temporary directory for tests."""
         temp_dir = tempfile.mkdtemp()
         yield Path(temp_dir)
         shutil.rmtree(temp_dir)
-    
+
     @pytest.mark.skipif(
-        not os.getenv('SERPER_API_KEY'),
-        reason="SERPER_API_KEY not available for real API test"
+        not os.getenv('SERPER_API_KEY'), reason="SERPER_API_KEY not available for real API test"
     )
     @pytest.mark.asyncio
     async def test_serper_search_real_api(self):
         """
         Test Serper.dev API with real API calls.
-        
+
         This test verifies that the Serper.dev integration can successfully
         search for images and return valid URLs when API key is available.
         """
         query = "blurry aadhaar card photo"
-        
+
         # Test the unified search interface
         urls = await search_images(query, engine="serper", limit=10)
-        
+
         # Should return a list (may be empty if API has issues)
         assert isinstance(urls, list)
-        
+
         # If we get URLs, verify they are valid
         if len(urls) > 0:
             # Verify URLs are valid strings
             for url in urls:
                 assert isinstance(url, str)
                 assert url.startswith(('http://', 'https://'))
-            
+
             # Check that we get reasonable results
             assert len(urls) >= 1, "Should return at least one URL with working API key"
             assert len(urls) <= 10, "Should not exceed requested limit"
         else:
             # If no URLs returned, it might be due to network issues or API limits
             print("No URLs returned - this may be due to network issues or API limits")
-    
+
     @pytest.mark.skipif(
-        not os.getenv('SERPER_API_KEY'),
-        reason="SERPER_API_KEY not available for download test"
+        not os.getenv('SERPER_API_KEY'), reason="SERPER_API_KEY not available for download test"
     )
     @pytest.mark.asyncio
     async def test_serper_download_real(self, tmp_path):
         """
         Test downloading images found via Serper.dev API.
-        
+
         This test verifies that images found through Serper can be successfully
         downloaded, saved to disk, and opened with PIL with valid dimensions.
         """
         query = "blurry aadhaar card photo"
-        
+
         # Search for images using Serper
         urls = await search_images(query, engine="serper", limit=5)
-        
+
         if len(urls) == 0:
             pytest.skip("No URLs found for download test - API may be unavailable")
-        
+
         # Download first few images
         test_urls = urls[:3]  # Test with first 3 URLs
         results = await download_images(test_urls, output_dir=str(tmp_path))
-        
+
         # If we got URLs but no downloads, it might be due to filtering or network issues
         if len(results) == 0:
-            pytest.skip("No images successfully downloaded - this may be due to filtering or network issues")
-        
+            pytest.skip(
+                "No images successfully downloaded - this may be due to filtering or network issues"
+            )
+
         # Verify downloaded files
-        for url, filepath in results.items():
+        for _url, filepath in results.items():
             file_path = Path(filepath)
-            
+
             # File should exist
             assert file_path.exists(), f"Downloaded file should exist: {filepath}"
-            
+
             # File should have content
             assert file_path.stat().st_size > 0, f"Downloaded file should not be empty: {filepath}"
-            
+
             # Should be able to open with PIL
             try:
                 with Image.open(file_path) as img:
                     width, height = img.size
-                    
+
                     # Verify dimensions are reasonable (> 100x100 as required)
                     assert width > 100, f"Image width should be > 100px, got {width}"
                     assert height > 100, f"Image height should be > 100px, got {height}"
-                    
+
                     # Verify it's a valid image format
-                    assert img.format in ['JPEG', 'PNG', 'WEBP'], f"Should be valid image format, got {img.format}"
-                    
+                    assert img.format in [
+                        'JPEG',
+                        'PNG',
+                        'WEBP',
+                    ], f"Should be valid image format, got {img.format}"
+
             except Exception as e:
                 pytest.fail(f"Failed to open downloaded image {filepath} with PIL: {e}")
-    
+
     @pytest.mark.asyncio
     async def test_serper_search_with_mock(self):
         """
         Test Serper.dev search functionality with mocked API responses.
-        
+
         This test ensures the Serper integration works correctly when the API
         returns valid responses, without requiring actual API calls.
         """
         query = "test document"
-        
+
         # Mock successful Serper API response
         mock_response_data = {
             'images': [
                 {'imageUrl': 'https://example.com/image1.jpg'},
                 {'imageUrl': 'https://example.com/image2.png'},
-                {'link': 'https://example.com/image3.webp'}  # Alternative field
+                {'link': 'https://example.com/image3.webp'},  # Alternative field
             ]
         }
-        
+
         # Create a proper async context manager mock
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.json = AsyncMock(return_value=mock_response_data)
-        
-        # Create async context manager
-        mock_context_manager = AsyncMock()
-        mock_context_manager.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_context_manager.__aexit__ = AsyncMock(return_value=None)
-        
-        # Mock the HTTP session
-        with patch('aiohttp.ClientSession') as mock_session_class:
-            mock_session = MagicMock()
-            mock_session.post.return_value = mock_context_manager
-            mock_session.close = AsyncMock()
-            mock_session_class.return_value = mock_session
-            
+
+        # Mock the HTTP request
+        with patch('requests.post') as mock_post:
+            mock_post.return_value.status_code = 200
+            mock_post.return_value.json.return_value = mock_response_data
+
             # Mock environment variable
             with patch.dict(os.environ, {'SERPER_API_KEY': 'test_key'}):
                 urls = await search_images(query, engine="serper", limit=10)
-        
+
         # Should return the mocked URLs
         assert isinstance(urls, list)
         assert len(urls) == 3
-        
+
         # Verify all URLs are present
         expected_urls = [
             'https://example.com/image1.jpg',
             'https://example.com/image2.png',
-            'https://example.com/image3.webp'
+            'https://example.com/image3.webp',
         ]
         for expected_url in expected_urls:
             assert expected_url in urls
-    
+
     @pytest.mark.asyncio
     async def test_serper_api_error_handling(self):
         """
         Test error handling when Serper.dev API returns errors.
-        
+
         This test verifies that the integration gracefully handles API errors
         and returns empty results instead of crashing.
         """
         query = "test query"
-        
+
         # Mock API error response
         mock_response = AsyncMock()
         mock_response.status = 429  # Rate limit error
-        
+
         # Create async context manager
-        mock_context_manager = AsyncMock()
-        mock_context_manager.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_context_manager.__aexit__ = AsyncMock(return_value=None)
-        
-        # Mock the HTTP session
-        with patch('aiohttp.ClientSession') as mock_session_class:
-            mock_session = MagicMock()
-            mock_session.post.return_value = mock_context_manager
-            mock_session.close = AsyncMock()
-            mock_session_class.return_value = mock_session
-            
+        # Mock the HTTP request
+        with patch('requests.post') as mock_post:
+            mock_post.return_value.status_code = 429
+            mock_post.return_value.text = 'rate limit'
+
             # Mock environment variable
             with patch.dict(os.environ, {'SERPER_API_KEY': 'test_key'}):
                 urls = await search_images(query, engine="serper", limit=10)
-        
+
         # Should return empty list on error
         assert isinstance(urls, list)
         assert len(urls) == 0
-    
+
     @pytest.mark.asyncio
     async def test_serper_no_api_key(self):
         """
         Test behavior when SERPER_API_KEY is not available.
-        
+
         This test verifies that the integration gracefully handles missing
         API keys and returns empty results with appropriate warnings.
         """
         query = "test query"
-        
+
         # Ensure no API key is set
         with patch.dict(os.environ, {}, clear=True):
             urls = await search_images(query, engine="serper", limit=10)
-        
+
         # Should return empty list when no API key
         assert isinstance(urls, list)
         assert len(urls) == 0
-    
+
     @pytest.mark.asyncio
     async def test_download_images_with_real_test_data(self, tmp_path):
         """
         Test download functionality with real image data but mocked network.
-        
+
         This test creates real image data and verifies the download mechanism
         works correctly with PIL validation.
         """
@@ -230,27 +222,27 @@ class TestSerperIntegration:
         img_bytes = io.BytesIO()
         test_img.save(img_bytes, format='JPEG')
         img_data = img_bytes.getvalue()
-        
+
         test_urls = ["https://example.com/test_image.jpg"]
-        
+
         # Mock HTTP response with real image data
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.headers = {'content-type': 'image/jpeg'}
         mock_response.read = AsyncMock(return_value=img_data)
-        
+
         # Create async context manager
         mock_context_manager = AsyncMock()
         mock_context_manager.__aenter__ = AsyncMock(return_value=mock_response)
         mock_context_manager.__aexit__ = AsyncMock(return_value=None)
-        
+
         # Mock the HTTP session
         with patch('aiohttp.ClientSession') as mock_session_class:
             mock_session = MagicMock()
             mock_session.get.return_value = mock_context_manager
             mock_session.close = AsyncMock()
             mock_session_class.return_value = mock_session
-            
+
             # Mock file operations to actually write the file
             with patch('aiofiles.open', create=True) as mock_open:
                 # Setup mock file writing that actually creates the file
@@ -263,100 +255,111 @@ class TestSerperIntegration:
                     class DummyFileCM:
                         async def __aenter__(self_inner):
                             return AsyncMock()
+
                         async def __aexit__(self_inner, exc_type, exc, tb):
                             pass
 
                     return DummyFileCM()
 
                 mock_open.side_effect = mock_write_file
-                
+
                 results = await download_images(test_urls, output_dir=str(tmp_path))
-        
+
         # Verify we got results
         assert len(results) == 1
-        
+
         # Verify the downloaded file
-        for url, filepath in results.items():
+        for _url, filepath in results.items():
             file_path = Path(filepath)
-            
+
             # File should exist
             assert file_path.exists(), f"Downloaded file should exist: {filepath}"
-            
+
             # File should have content
             assert file_path.stat().st_size > 0, f"Downloaded file should not be empty: {filepath}"
-            
+
             # Should be able to open with PIL and verify dimensions
             with Image.open(file_path) as img:
                 width, height = img.size
-                
+
                 # Verify it meets our requirements
                 assert width > 100, f"Image width should be > 100px, got {width}"
                 assert height > 100, f"Image height should be > 100px, got {height}"
                 assert img.format == 'JPEG', f"Should be JPEG format, got {img.format}"
-    
+
     @pytest.mark.asyncio
     async def test_unified_search_interface_engines(self):
         """
         Test that the unified search interface supports all expected engines.
-        
+
         This test verifies that the search_images function correctly routes
         requests to different search engines.
         """
         query = "test"
-        
+
         # Test all supported engines with mocked responses
         engines = ["serper", "serpapi", "unsplash", "flickr"]
-        
+
         for engine in engines:
             # Mock successful response for each engine
             mock_response = AsyncMock()
             mock_response.status = 200
-            
+
             if engine == "serper":
-                mock_response.json = AsyncMock(return_value={'images': [{'imageUrl': 'http://test.com/1.jpg'}]})
+                mock_response.json = AsyncMock(
+                    return_value={'images': [{'imageUrl': 'http://test.com/1.jpg'}]}
+                )
                 mock_method = 'post'
             else:
                 mock_response.json = AsyncMock(return_value={})
                 mock_method = 'get'
-            
+
             # Create async context manager
             mock_context_manager = AsyncMock()
             mock_context_manager.__aenter__ = AsyncMock(return_value=mock_response)
             mock_context_manager.__aexit__ = AsyncMock(return_value=None)
-            
-            with patch('aiohttp.ClientSession') as mock_session_class:
+
+            with (
+                patch('aiohttp.ClientSession') as mock_session_class,
+                patch('requests.post') as mock_post,
+            ):
                 mock_session = MagicMock()
                 if mock_method == 'post':
                     mock_session.post.return_value = mock_context_manager
+                    mock_post.return_value.status_code = 200
+                    mock_post.return_value.json.return_value = {
+                        'images': [{'imageUrl': 'http://test.com/1.jpg'}]
+                    }
                 else:
                     mock_session.get.return_value = mock_context_manager
                 mock_session.close = AsyncMock()
                 mock_session_class.return_value = mock_session
-                
+
                 # Mock appropriate API keys
                 env_vars = {
                     'SERPER_API_KEY': 'test_key',
                     'SERPAPI_KEY': 'test_key',
                     'UNSPLASH_ACCESS_KEY': 'test_key',
-                    'FLICKR_KEY': 'test_key'
+                    'FLICKR_KEY': 'test_key',
                 }
-                
+
                 with patch.dict(os.environ, env_vars):
                     urls = await search_images(query, engine=engine, limit=5)
-                
+
                 # Should return a list (content depends on mocked response)
                 assert isinstance(urls, list)
-    
+
     def test_invalid_engine_raises_error(self):
         """
         Test that using an invalid engine raises appropriate error.
-        
+
         This test verifies that the unified interface properly validates
         engine parameters and raises clear errors for unsupported engines.
         """
+
         async def test_invalid():
             return await search_images("test", engine="invalid_engine", limit=5)
-        
+
         # Should raise ValueError for invalid engine
         with pytest.raises(ValueError, match="Unsupported search engine"):
-            asyncio.run(test_invalid()) 
+            asyncio.run(test_invalid())


### PR DESCRIPTION
## Summary
- refactor `GPT4VAnalyzer` to use `requests.post` instead of `aiohttp`
- drop async keywords from analyzer helpers
- update tests for analyzer changes and adjust Serper mocks

## Testing
- `ruff check gpt4v_analyzer.py tests/test_integration_complete.py tests/test_serper_integration.py`
- `black gpt4v_analyzer.py tests/test_integration_complete.py tests/test_serper_integration.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68411e28f20c8330ba5238d4998a18db