### PR TITLE
Handle zero success rate in classification summary

### DIFF
--- a/gpt4v_image_labeler.py
+++ b/gpt4v_image_labeler.py
@@ -301,21 +301,25 @@ def generate_classification_summary(results: List[Dict], output_file: str):
         f.write(f"- Total Images: {total_images}\n")
         f.write(f"- Successfully Classified: {successful}\n")
         f.write(f"- Failed: {failed}\n")
-        f.write(f"- Success Rate: {successful/total_images*100:.1f}%\n\n")
+        success_rate = successful / total_images * 100 if total_images else 0
+        f.write(f"- Success Rate: {success_rate:.1f}%\n\n")
         
         f.write("## Document Categories\n")
         for cat, count in sorted(categories.items(), key=lambda x: x[1], reverse=True):
-            f.write(f"- {cat}: {count} ({count/successful*100:.1f}%)\n")
+            percentage = count / successful * 100 if successful else 0.0
+            f.write(f"- {cat}: {count} ({percentage:.1f}%)\n")
         f.write("\n")
         
         f.write("## OCR Difficulty Distribution\n")
         for diff, count in sorted(difficulties.items(), key=lambda x: x[1], reverse=True):
-            f.write(f"- {diff}: {count} ({count/successful*100:.1f}%)\n")
+            percentage = count / successful * 100 if successful else 0.0
+            f.write(f"- {diff}: {count} ({percentage:.1f}%)\n")
         f.write("\n")
         
         f.write("## Language Distribution\n")
         for lang, count in sorted(languages.items(), key=lambda x: x[1], reverse=True):
-            f.write(f"- {lang}: {count} ({count/successful*100:.1f}%)\n")
+            percentage = count / successful * 100 if successful else 0.0
+            f.write(f"- {lang}: {count} ({percentage:.1f}%)\n")
         f.write("\n")
     
     print(f"📊 Summary report saved to: {report_file}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,5 @@
-import os
-from pathlib import Path
 from unittest.mock import AsyncMock, patch
+
 import pytest
 
 from ocrdlp import OCRDLPCli
@@ -102,7 +101,7 @@ async def test_pipeline_command(tmp_path):
 
     assert exit_code == 0
     mock_search.assert_awaited_once()
-    mock_download_fn.assert_awaited_once_with(mock_urls, output_dir=str(tmp_path))
+    mock_download_fn.assert_awaited_once_with(mock_urls, output_dir=str(tmp_path / "images"))
     mock_classify.assert_awaited_once()
 
 

--- a/tests/test_image_labeling.py
+++ b/tests/test_image_labeling.py
@@ -1,0 +1,17 @@
+from gpt4v_image_labeler import generate_classification_summary
+
+
+def test_generate_summary_all_failed(tmp_path):
+    results = [{"error": "fail"} for _ in range(3)]
+    output_file = tmp_path / "labels.jsonl"
+
+    generate_classification_summary(results, str(output_file))
+
+    summary_file = output_file.with_name(output_file.stem + "_summary.md")
+    assert summary_file.exists()
+
+    content = summary_file.read_text()
+    assert "- Successfully Classified: 0" in content
+    assert "- Failed: 3" in content
+    assert "- Success Rate: 0.0%" in content
+


### PR DESCRIPTION
## Summary
- handle zero success case when generating classification summary
- test that summary runs when all classifications fail
- switch crawler search helpers to use requests instead of aiohttp
- fix CLI and integration tests for new search implementation

## Testing
- `pytest -q tests/test_image_labeling.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841252d85c48330ad931308dbd783a8