### PR TITLE
Refactor ImageCrawler to remove aiohttp

### DIFF
--- a/crawler/image_crawler.py
+++ b/crawler/image_crawler.py
@@ -3,15 +3,13 @@ Image crawler for collecting images from various sources.
 """
 
 import asyncio
-import aiohttp
-import aiofiles
 import os
-import json
 from typing import List, Dict, Optional, Set
-from urllib.parse import urlparse, urljoin
+from urllib.parse import urlparse
 from pathlib import Path
 import logging
 from tqdm.asyncio import tqdm
+import requests
 
 from .filters import ImageFilter
 from .deduplicator import ImageDeduplicator
@@ -20,76 +18,78 @@ from .search import ImageSearchEngine
 
 class ImageCrawler:
     """Async image crawler with filtering and deduplication."""
-    
-    def __init__(self, 
-                 output_dir: str = "ocr_dataset/full",
-                 max_concurrent: int = 10,
-                 retry_attempts: int = 3):
+
+    def __init__(
+        self,
+        output_dir: str = "ocr_dataset/full",
+        max_concurrent: int = 10,
+        retry_attempts: int = 3,
+    ):
         self.output_dir = Path(output_dir)
         self.output_dir.mkdir(parents=True, exist_ok=True)
         self.max_concurrent = max_concurrent
         self.retry_attempts = retry_attempts
-        self.session: Optional[aiohttp.ClientSession] = None
         self.filter = ImageFilter()
         self.deduplicator = ImageDeduplicator()
         self.downloaded_urls: Set[str] = set()
         self.search_engine: Optional[ImageSearchEngine] = None
-        
+
         # Setup logging
         logging.basicConfig(level=logging.INFO)
         self.logger = logging.getLogger(__name__)
-    
+
     async def __aenter__(self):
         """Async context manager entry."""
-        connector = aiohttp.TCPConnector(limit=self.max_concurrent)
-        timeout = aiohttp.ClientTimeout(total=30)
-        self.session = aiohttp.ClientSession(
-            connector=connector,
-            timeout=timeout,
-            headers={'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'}
-        )
-        self.search_engine = ImageSearchEngine(self.session)
+        self.search_engine = ImageSearchEngine()
         return self
-    
+
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         """Async context manager exit."""
-        if self.session:
-            await self.session.close()
-    
-    async def search_images(self, keywords: List[str], max_per_keyword: int = 100, 
-                           engine: str = "mixed") -> List[str]:
+        pass
+
+    async def search_images(
+        self, keywords: List[str], max_per_keyword: int = 100, engine: str = "mixed"
+    ) -> List[str]:
         """
         Search for image URLs using multiple sources or a specific engine.
-        
+
         Args:
             keywords: List of search keywords
             max_per_keyword: Maximum URLs per keyword
             engine: Search engine to use ("mixed", "serper", "serpapi", "unsplash", "flickr")
         """
         all_urls = []
-        
+
         for keyword in keywords:
             self.logger.info(f"Searching images for keyword: {keyword}")
-            
+
             if engine == "mixed":
                 # Use multiple sources (legacy behavior)
                 urls = []
-                urls.extend(await self._search_engine_wrapper("serper", keyword, max_per_keyword // 4))
-                urls.extend(await self._search_engine_wrapper("unsplash", keyword, max_per_keyword // 4))
-                urls.extend(await self._search_engine_wrapper("serpapi", keyword, max_per_keyword // 4))
-                urls.extend(await self._search_engine_wrapper("flickr", keyword, max_per_keyword // 4))
+                urls.extend(
+                    await self._search_engine_wrapper("serper", keyword, max_per_keyword // 4)
+                )
+                urls.extend(
+                    await self._search_engine_wrapper("unsplash", keyword, max_per_keyword // 4)
+                )
+                urls.extend(
+                    await self._search_engine_wrapper("serpapi", keyword, max_per_keyword // 4)
+                )
+                urls.extend(
+                    await self._search_engine_wrapper("flickr", keyword, max_per_keyword // 4)
+                )
             else:
                 # Use specific engine
                 urls = await self._search_engine_wrapper(engine, keyword, max_per_keyword)
-            
+
             # Remove duplicates and add to main list
             unique_urls = list(set(urls))[:max_per_keyword]
             all_urls.extend(unique_urls)
-            
+
             self.logger.info(f"Found {len(unique_urls)} unique URLs for '{keyword}' using {engine}")
-        
+
         return list(set(all_urls))  # Remove global duplicates
-    
+
     async def _search_engine_wrapper(self, engine: str, keyword: str, limit: int) -> List[str]:
         """Wrapper for the unified search engine interface."""
         try:
@@ -102,15 +102,15 @@ class ImageCrawler:
     async def _search_unsplash(self, keyword: str, limit: int) -> List[str]:
         """Search Unsplash for images."""
         return await self._search_engine_wrapper("unsplash", keyword, limit)
-    
+
     async def _search_google_images(self, keyword: str, limit: int) -> List[str]:
         """Search Google Images via SerpAPI."""
         return await self._search_engine_wrapper("serpapi", keyword, limit)
-    
+
     async def _search_flickr(self, keyword: str, limit: int) -> List[str]:
         """Search Flickr for images."""
         return await self._search_engine_wrapper("flickr", keyword, limit)
-    
+
     async def _search_serper(self, keyword: str, limit: int) -> List[str]:
         """Search images using Serper.dev API."""
         return await self._search_engine_wrapper("serper", keyword, limit)
@@ -118,14 +118,14 @@ class ImageCrawler:
     async def download_images(self, urls: List[str]) -> Dict[str, str]:
         """Download images with filtering and deduplication."""
         semaphore = asyncio.Semaphore(self.max_concurrent)
-        
+
         # Create download tasks
         tasks = []
         for i, url in enumerate(urls):
             if url not in self.downloaded_urls:
                 task = self._download_single_image(semaphore, url, f"image_{i:06d}")
                 tasks.append(task)
-        
+
         # Execute downloads with progress bar
         results = {}
         if tasks:
@@ -133,83 +133,88 @@ class ImageCrawler:
             for result in completed_tasks:
                 if result:
                     results.update(result)
-        
+
         self.logger.info(f"Successfully downloaded {len(results)} images")
         return results
-    
-    async def _download_single_image(self, semaphore: asyncio.Semaphore, 
-                                   url: str, filename_base: str) -> Optional[Dict[str, str]]:
+
+    async def _download_single_image(
+        self, semaphore: asyncio.Semaphore, url: str, filename_base: str
+    ) -> Optional[Dict[str, str]]:
         """Download a single image with retry logic."""
+
         async with semaphore:
             for attempt in range(self.retry_attempts):
                 try:
-                    async with self.session.get(url) as response:
-                        if response.status == 200:
-                            content = await response.read()
-                            
-                            # Determine file extension
-                            content_type = response.headers.get('content-type', '')
-                            if 'jpeg' in content_type or 'jpg' in content_type:
-                                ext = '.jpg'
-                            elif 'png' in content_type:
-                                ext = '.png'
-                            elif 'webp' in content_type:
-                                ext = '.webp'
+                    response = await asyncio.to_thread(requests.get, url, timeout=30)
+
+                    if response.status_code == 200:
+                        content = response.content
+
+                        # Determine file extension
+                        content_type = response.headers.get("content-type", "")
+                        if "jpeg" in content_type or "jpg" in content_type:
+                            ext = ".jpg"
+                        elif "png" in content_type:
+                            ext = ".png"
+                        elif "webp" in content_type:
+                            ext = ".webp"
+                        else:
+                            parsed = urlparse(url)
+                            path_ext = os.path.splitext(parsed.path)[1].lower()
+                            ext = (
+                                path_ext
+                                if path_ext in [".jpg", ".jpeg", ".png", ".webp"]
+                                else ".jpg"
+                            )
+
+                        filename = f"{filename_base}{ext}"
+                        filepath = self.output_dir / filename
+
+                        await asyncio.to_thread(self._write_file, filepath, content)
+
+                        if await self.filter.is_valid_image(filepath):
+                            if not await self.deduplicator.is_duplicate(filepath):
+                                self.downloaded_urls.add(url)
+                                return {url: str(filepath)}
                             else:
-                                # Try to guess from URL
-                                parsed = urlparse(url)
-                                path_ext = os.path.splitext(parsed.path)[1].lower()
-                                ext = path_ext if path_ext in ['.jpg', '.jpeg', '.png', '.webp'] else '.jpg'
-                            
-                            filename = f"{filename_base}{ext}"
-                            filepath = self.output_dir / filename
-                            
-                            # Save image
-                            async with aiofiles.open(filepath, 'wb') as f:
-                                await f.write(content)
-                            
-                            # Apply filters
-                            if await self.filter.is_valid_image(filepath):
-                                # Check for duplicates
-                                if not await self.deduplicator.is_duplicate(filepath):
-                                    self.downloaded_urls.add(url)
-                                    return {url: str(filepath)}
-                                else:
-                                    # Remove duplicate
-                                    os.remove(filepath)
-                                    self.logger.debug(f"Removed duplicate image: {filename}")
-                            else:
-                                # Remove invalid image
                                 os.remove(filepath)
-                                self.logger.debug(f"Removed invalid image: {filename}")
-                            
-                            break
-                        
-                        elif response.status in [404, 403, 410]:
-                            # Don't retry for these errors
-                            break
-                            
+                                self.logger.debug(f"Removed duplicate image: {filename}")
+                        else:
+                            os.remove(filepath)
+                            self.logger.debug(f"Removed invalid image: {filename}")
+
+                        break
+
+                    elif response.status_code in [404, 403, 410]:
+                        break
+
                 except Exception as e:
                     if attempt == self.retry_attempts - 1:
-                        self.logger.error(f"Failed to download {url} after {self.retry_attempts} attempts: {e}")
+                        self.logger.error(
+                            f"Failed to download {url} after {self.retry_attempts} attempts: {e}"
+                        )
                     else:
-                        await asyncio.sleep(1)  # Wait before retry
-        
+                        await asyncio.sleep(1)
+
         return None
-    
+
+    def _write_file(self, path: Path, data: bytes) -> None:
+        with open(path, "wb") as f:
+            f.write(data)
+
     async def crawl_keywords(self, keywords: List[str], max_images: int = 500) -> Dict[str, str]:
         """Main crawling method."""
         self.logger.info(f"Starting crawl for {len(keywords)} keywords, max {max_images} images")
-        
+
         # Search for image URLs
         max_per_keyword = max_images // len(keywords) if keywords else max_images
         urls = await self.search_images(keywords, max_per_keyword)
-        
+
         # Limit total URLs
         urls = urls[:max_images]
         self.logger.info(f"Found {len(urls)} total URLs to download")
-        
+
         # Download images
         results = await self.download_images(urls)
-        
-        return results 
+
+        return results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,6 @@ license = {text = "MIT"}
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "aiohttp>=3.9.1",
-    "aiofiles>=23.2.0",
     "python-dotenv>=1.0.0",
     "Pillow>=10.1.0",
     "pytest>=7.4.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-aiohttp>=3.9.0
-aiofiles>=23.0.0
 python-dotenv>=1.0.0
 Pillow>=10.0.0
 pytest>=7.0.0

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -8,7 +8,7 @@ import tempfile
 import shutil
 import os
 from pathlib import Path
-from unittest.mock import Mock, patch, AsyncMock, MagicMock
+from unittest.mock import Mock, patch, AsyncMock, MagicMock, mock_open
 from PIL import Image
 
 from crawler import ImageCrawler, ImageFilter, ImageDeduplicator
@@ -16,24 +16,24 @@ from crawler import ImageCrawler, ImageFilter, ImageDeduplicator
 
 class TestImageCrawler:
     """Test cases for ImageCrawler class."""
-    
+
     @pytest.fixture
     def temp_dir(self):
         """Create temporary directory for tests."""
         temp_dir = tempfile.mkdtemp()
         yield Path(temp_dir)
         shutil.rmtree(temp_dir)
-    
+
     @pytest.fixture
     def crawler(self, temp_dir):
         """Create ImageCrawler instance for testing."""
         return ImageCrawler(output_dir=str(temp_dir), max_concurrent=2)
-    
+
     @pytest.mark.asyncio
     async def test_search_images_returns_urls(self, crawler):
         """Test that search_images returns a list of URLs."""
         keywords = ["test", "sample"]
-        
+
         # Mock the search wrapper to return test URLs for each engine
         async def mock_search_wrapper(engine, keyword, limit):
             if engine == "serper":
@@ -45,10 +45,10 @@ class TestImageCrawler:
             return []
 
         with patch.object(crawler, '_search_engine_wrapper', side_effect=mock_search_wrapper):
-            
+
             async with crawler:
                 urls = await crawler.search_images(keywords, max_per_keyword=10)
-            
+
             assert isinstance(urls, list)
             assert len(urls) >= 0  # Should return some URLs (mocked)
             # Check that we get at least 90% of expected URLs (requirement)
@@ -56,33 +56,35 @@ class TestImageCrawler:
             assert len(urls) >= expected_min or len(urls) == 3  # Allow for mocked data
 
     @pytest.mark.skipif(
-        not any([os.getenv('UNSPLASH_ACCESS_KEY'), os.getenv('SERPAPI_KEY'), os.getenv('FLICKR_KEY')]),
-        reason="No API keys available for image search"
+        not any(
+            [os.getenv('UNSPLASH_ACCESS_KEY'), os.getenv('SERPAPI_KEY'), os.getenv('FLICKR_KEY')]
+        ),
+        reason="No API keys available for image search",
     )
     @pytest.mark.asyncio
     async def test_search_images_real_api(self, tmp_path):
         """
         Test search_images function with real API calls.
-        
+
         This test verifies that the search function can successfully return
         non-empty image URL lists when API keys are available and working.
         """
         crawler = ImageCrawler(output_dir=str(tmp_path), max_concurrent=2)
         keywords = ["blurry aadhaar card photo"]
-        
+
         async with crawler:
             urls = await crawler.search_images(keywords, max_per_keyword=10)
-        
+
         # Should return a list (may be empty if API calls fail)
         assert isinstance(urls, list)
-        
+
         # If we get URLs, verify they are valid
         if len(urls) > 0:
             # Verify URLs are valid strings
             for url in urls:
                 assert isinstance(url, str)
                 assert url.startswith(('http://', 'https://'))
-            
+
             # Check that we get reasonable results
             assert len(urls) >= 1, "Should return at least one URL with working API keys"
         else:
@@ -91,144 +93,133 @@ class TestImageCrawler:
             print("No URLs returned - this may be due to network issues or API key problems")
 
     @pytest.mark.skipif(
-        not any([os.getenv('UNSPLASH_ACCESS_KEY'), os.getenv('SERPAPI_KEY'), os.getenv('FLICKR_KEY')]),
-        reason="No API keys available for image download test"
+        not any(
+            [os.getenv('UNSPLASH_ACCESS_KEY'), os.getenv('SERPAPI_KEY'), os.getenv('FLICKR_KEY')]
+        ),
+        reason="No API keys available for image download test",
     )
     @pytest.mark.asyncio
     async def test_download_image_real(self, tmp_path):
         """
         Test download_images function with real image downloads.
-        
+
         This test verifies that images can be successfully downloaded,
         saved to disk, and opened with PIL with valid dimensions.
         """
         crawler = ImageCrawler(output_dir=str(tmp_path), max_concurrent=2)
         keywords = ["blurry aadhaar card photo"]
-        
+
         async with crawler:
             # First search for images
             urls = await crawler.search_images(keywords, max_per_keyword=5)
-            
+
             if len(urls) == 0:
                 pytest.skip("No URLs found for download test - API may be unavailable")
-            
+
             # Download first few images
             test_urls = urls[:3]  # Test with first 3 URLs
             results = await crawler.download_images(test_urls)
-        
+
         # If we got URLs but no downloads, it might be due to filtering or network issues
         if len(results) == 0:
-            pytest.skip("No images successfully downloaded - this may be due to filtering or network issues")
-        
+            pytest.skip(
+                "No images successfully downloaded - this may be due to filtering or network issues"
+            )
+
         # Verify downloaded files
         for url, filepath in results.items():
             file_path = Path(filepath)
-            
+
             # File should exist
             assert file_path.exists(), f"Downloaded file should exist: {filepath}"
-            
+
             # File should have content
             assert file_path.stat().st_size > 0, f"Downloaded file should not be empty: {filepath}"
-            
+
             # Should be able to open with PIL
             try:
                 with Image.open(file_path) as img:
                     width, height = img.size
-                    
+
                     # Verify dimensions are reasonable (> 100x100 as required)
                     assert width > 100, f"Image width should be > 100px, got {width}"
                     assert height > 100, f"Image height should be > 100px, got {height}"
-                    
+
                     # Verify it's a valid image format
-                    assert img.format in ['JPEG', 'PNG', 'WEBP'], f"Should be valid image format, got {img.format}"
-                    
+                    assert img.format in [
+                        'JPEG',
+                        'PNG',
+                        'WEBP',
+                    ], f"Should be valid image format, got {img.format}"
+
             except Exception as e:
                 pytest.fail(f"Failed to open downloaded image {filepath} with PIL: {e}")
 
     @pytest.mark.asyncio
     async def test_download_images_with_filtering(self, crawler, temp_dir):
         """Test image download with filtering applied."""
-        test_urls = [
-            "http://example.com/test1.jpg",
-            "http://example.com/test2.jpg"
-        ]
-        
+        test_urls = ["http://example.com/test1.jpg", "http://example.com/test2.jpg"]
+
         # Mock successful HTTP responses
         mock_response = Mock()
-        mock_response.status = 200
+        mock_response.status_code = 200
         mock_response.headers = {'content-type': 'image/jpeg'}
-        mock_response.read = AsyncMock(return_value=b"fake_image_data")
-        
-        # Mock filter to accept first image, reject second
-        with patch.object(crawler.filter, 'is_valid_image', side_effect=[True, False]), \
-             patch.object(crawler.deduplicator, 'is_duplicate', return_value=False), \
-             patch('aiofiles.open', create=True) as mock_open:
-            
-            mock_open.return_value.__aenter__.return_value.write = AsyncMock()
-            
-            async with crawler:
-                class DummyCM:
-                    def __init__(self, resp):
-                        self.resp = resp
-                    async def __aenter__(self):
-                        return self.resp
-                    async def __aexit__(self, exc_type, exc, tb):
-                        pass
+        mock_response.content = b"fake_image_data"
 
-                crawler.session.get = MagicMock(return_value=DummyCM(mock_response))
+        # Mock filter to accept first image, reject second
+        with (
+            patch.object(crawler.filter, 'is_valid_image', side_effect=[True, False]),
+            patch.object(crawler.deduplicator, 'is_duplicate', return_value=False),
+            patch('builtins.open', mock_open()),
+            patch('requests.get', return_value=mock_response) as mock_get,
+        ):
+
+            async with crawler:
                 crawler.retry_attempts = 1
                 results = await crawler.download_images(test_urls)
-            
+
             # Should only get one result due to filtering
             assert len(results) <= len(test_urls)
             # Verify filtering was applied correctly
             assert crawler.filter.is_valid_image.call_count == 2
-    
+
     @pytest.mark.asyncio
     async def test_retry_logic_on_failure(self, crawler):
         """Test retry logic when downloads fail."""
         test_urls = ["http://example.com/fail.jpg"]
-        
+
         # Mock failing HTTP response
         mock_response = Mock()
-        mock_response.status = 500
-        
-        async with crawler:
-            class DummyCM:
-                def __init__(self, resp):
-                    self.resp = resp
-                async def __aenter__(self):
-                    return self.resp
-                async def __aexit__(self, exc_type, exc, tb):
-                    pass
+        mock_response.status_code = 500
 
-            crawler.session.get = MagicMock(return_value=DummyCM(mock_response))
-            crawler.retry_attempts = 1
-            results = await crawler.download_images(test_urls)
-        
+        with patch('requests.get', return_value=mock_response) as mock_get:
+            async with crawler:
+                crawler.retry_attempts = 1
+                results = await crawler.download_images(test_urls)
+
         # Should return empty results after retries
         assert len(results) == 0
         # Verify retry attempts were made
-        assert crawler.session.get.call_count >= crawler.retry_attempts
+        assert mock_get.call_count >= crawler.retry_attempts
 
     @pytest.mark.asyncio
     async def test_search_images_with_mock_urls(self, tmp_path):
         """
         Test search_images function behavior with mocked successful responses.
-        
+
         This test ensures the function works correctly when APIs return valid URLs.
         """
         crawler = ImageCrawler(output_dir=str(tmp_path), max_concurrent=2)
         keywords = ["test document"]
-        
+
         # Mock successful API responses for all 4 engines
         mock_urls = [
             "https://example.com/image1.jpg",
-            "https://example.com/image2.png", 
+            "https://example.com/image2.png",
             "https://example.com/image3.webp",
-            "https://example.com/image4.jpg"
+            "https://example.com/image4.jpg",
         ]
-        
+
         # Mock the search engine wrapper to return different URLs for each engine
         async def mock_search_wrapper(engine, keyword, limit):
             if engine == "serper":
@@ -240,19 +231,19 @@ class TestImageCrawler:
             elif engine == "flickr":
                 return mock_urls[3:]
             return []
-        
+
         with patch.object(crawler, '_search_engine_wrapper', side_effect=mock_search_wrapper):
             async with crawler:
                 urls = await crawler.search_images(keywords, max_per_keyword=10, engine="mixed")
-        
+
         # Should return the mocked URLs
         assert isinstance(urls, list)
         assert len(urls) == 4
-        
+
         # Verify all URLs are present
         for expected_url in mock_urls:
             assert expected_url in urls
-        
+
         # Check that we meet the >90% URL extraction requirement
         expected_min = len(keywords) * 4 * 0.9  # 4 sources per keyword, 90% success
         assert len(urls) >= expected_min
@@ -261,42 +252,50 @@ class TestImageCrawler:
     async def test_download_images_with_real_urls(self, tmp_path):
         """
         Test download_images function with publicly available test images.
-        
+
         This test uses known public image URLs to verify download functionality.
         """
         crawler = ImageCrawler(output_dir=str(tmp_path), max_concurrent=2)
-        
+
         # Use publicly available test images
         test_urls = [
             "https://httpbin.org/image/jpeg",  # Returns a JPEG image
-            "https://httpbin.org/image/png",   # Returns a PNG image
+            "https://httpbin.org/image/png",  # Returns a PNG image
         ]
-        
+
         async with crawler:
             results = await crawler.download_images(test_urls)
-        
+
         # Should successfully download at least one image
         # (Some URLs might fail due to filtering or network issues)
         if len(results) > 0:
             # Verify downloaded files
             for url, filepath in results.items():
                 file_path = Path(filepath)
-                
+
                 # File should exist
                 assert file_path.exists(), f"Downloaded file should exist: {filepath}"
-                
+
                 # File should have content
-                assert file_path.stat().st_size > 0, f"Downloaded file should not be empty: {filepath}"
-                
+                assert (
+                    file_path.stat().st_size > 0
+                ), f"Downloaded file should not be empty: {filepath}"
+
                 # Should be able to open with PIL
                 try:
                     with Image.open(file_path) as img:
                         width, height = img.size
-                        
+
                         # Verify it's a valid image
-                        assert width > 0 and height > 0, f"Image should have valid dimensions: {width}x{height}"
-                        assert img.format in ['JPEG', 'PNG', 'WEBP'], f"Should be valid image format, got {img.format}"
-                        
+                        assert (
+                            width > 0 and height > 0
+                        ), f"Image should have valid dimensions: {width}x{height}"
+                        assert img.format in [
+                            'JPEG',
+                            'PNG',
+                            'WEBP',
+                        ], f"Should be valid image format, got {img.format}"
+
                 except Exception as e:
                     pytest.fail(f"Failed to open downloaded image {filepath} with PIL: {e}")
         else:
@@ -307,122 +306,118 @@ class TestImageCrawler:
     async def test_download_images_basic_functionality(self, tmp_path):
         """
         Test basic download functionality with mocked network responses.
-        
+
         This test verifies that the download mechanism works by mocking
         HTTP responses and file operations.
         """
         crawler = ImageCrawler(output_dir=str(tmp_path), max_concurrent=2)
-        
+
         test_urls = ["https://example.com/test_image.jpg"]
-        
+
         # Create a real test image in memory
         from PIL import Image
         import io
-        
+
         # Create a 300x300 test image
         test_img = Image.new('RGB', (300, 300), color='red')
         img_bytes = io.BytesIO()
         test_img.save(img_bytes, format='JPEG')
         img_data = img_bytes.getvalue()
-        
+
         # Mock HTTP response
         mock_response = Mock()
-        mock_response.status = 200
+        mock_response.status_code = 200
         mock_response.headers = {'content-type': 'image/jpeg'}
-        mock_response.read = AsyncMock(return_value=img_data)
-        
+        mock_response.content = img_data
+
         # Mock file operations
-        with patch.object(crawler.filter, 'is_valid_image', return_value=True), \
-             patch.object(crawler.deduplicator, 'is_duplicate', return_value=False), \
-             patch('aiofiles.open', create=True) as mock_open:
-            
-            # Setup mock file writing
-            mock_file = Mock()
-            mock_file.write = AsyncMock()
-            mock_open.return_value.__aenter__.return_value = mock_file
-            
-            # Create actual file for PIL to read
-            test_file_path = tmp_path / "image_000000.jpg"
-            test_img.save(test_file_path)
-            
+        # Create actual file for PIL to read
+        test_file_path = tmp_path / "image_000000.jpg"
+        test_img.save(test_file_path)
+
+        with (
+            patch.object(crawler.filter, 'is_valid_image', return_value=True),
+            patch.object(crawler.deduplicator, 'is_duplicate', return_value=False),
+            patch('builtins.open', mock_open()),
+            patch('requests.get', return_value=mock_response) as mock_get,
+        ):
+
             async with crawler:
-                crawler.session.get = AsyncMock(return_value=mock_response)
-                
                 # Mock the file path return
                 with patch('pathlib.Path.exists', return_value=True):
                     results = await crawler.download_images(test_urls)
-        
+
         # Manually verify the test image we created
         assert test_file_path.exists(), "Test image file should exist"
-        
+
         # Verify we can open it with PIL and check dimensions
         with Image.open(test_file_path) as img:
             width, height = img.size
-            
+
             # Verify it meets our requirements
             assert width > 100, f"Image width should be > 100px, got {width}"
             assert height > 100, f"Image height should be > 100px, got {height}"
             assert img.format == 'JPEG', f"Should be JPEG format, got {img.format}"
-            
+
         # The test passes if we can successfully create and verify the image
         assert True, "Successfully created and verified test image with PIL"
 
 
 class TestImageFilter:
     """Test cases for ImageFilter class."""
-    
+
     @pytest.fixture
     def filter_instance(self):
         """Create ImageFilter instance for testing."""
         return ImageFilter(min_size=100, max_size=2000, min_file_size=0)
-    
+
     @pytest.fixture
     def temp_image(self, temp_dir):
         """Create a temporary test image."""
         from PIL import Image
-        
+
         # Create a simple test image
         img = Image.new('RGB', (500, 500), color='red')
         image_path = temp_dir / "test_image.jpg"
         img.save(image_path)
         return image_path
-    
+
     @pytest.fixture
     def temp_dir(self):
         """Create temporary directory for tests."""
         temp_dir = tempfile.mkdtemp()
         yield Path(temp_dir)
         shutil.rmtree(temp_dir)
-    
+
     @pytest.mark.asyncio
     async def test_valid_image_passes_filter(self, filter_instance, temp_image):
         """Test that valid images pass the filter."""
         result = await filter_instance.is_valid_image(temp_image)
         assert result is True
-    
+
     @pytest.mark.asyncio
     async def test_filter_conditions_applied(self, filter_instance):
         """Test that filter conditions are properly applied."""
         # Test with mock image properties
         with patch.object(filter_instance, '_check_image_properties') as mock_check:
             mock_check.return_value = False  # Simulate failed filter
-            
+
             # Create a fake file for testing
             temp_dir = tempfile.mkdtemp()
             fake_file = Path(temp_dir) / "fake.jpg"
             fake_file.write_bytes(b"fake_data" * 1000)  # Ensure minimum file size
-            
+
             try:
                 result = await filter_instance.is_valid_image(fake_file)
                 assert result is False
                 assert mock_check.called
             finally:
                 shutil.rmtree(temp_dir)
-    
+
     def test_get_image_info(self, filter_instance, temp_image):
         """Test image information extraction."""
         info = filter_instance.get_image_info(temp_image)
-        
+
         assert 'filename' in info
         assert 'format' in info
         assert 'size' in info
@@ -432,91 +427,91 @@ class TestImageFilter:
 
 class TestImageDeduplicator:
     """Test cases for ImageDeduplicator class."""
-    
+
     @pytest.fixture
     def temp_dir(self):
         """Create temporary directory for tests."""
         temp_dir = tempfile.mkdtemp()
         yield Path(temp_dir)
         shutil.rmtree(temp_dir)
-    
+
     @pytest.fixture
     def deduplicator(self, temp_dir):
         """Create ImageDeduplicator instance for testing."""
         hash_db_path = temp_dir / "test_hashes.json"
         return ImageDeduplicator(hash_db_path=str(hash_db_path), threshold=0)
-    
+
     @pytest.fixture
     def test_images(self, temp_dir):
         """Create test images for deduplication testing."""
         from PIL import Image
-        
+
         # Create two identical images
         img1 = Image.new('RGB', (100, 100), color='blue')
         img2 = Image.new('RGB', (100, 100), color='blue')
         img3 = Image.new('RGB', (100, 100), color='green')
         for x in range(0, 100, 10):
             img3.putpixel((x, 0), (255, 0, 0))  # add variance
-        
+
         path1 = temp_dir / "image1.jpg"
         path2 = temp_dir / "image2.jpg"
         path3 = temp_dir / "image3.jpg"
-        
+
         img1.save(path1)
         img2.save(path2)
         img3.save(path3)
-        
+
         return path1, path2, path3
-    
+
     @pytest.mark.asyncio
     @pytest.mark.xfail(reason="hash calculation may treat solid colors as duplicates")
     async def test_duplicate_detection(self, deduplicator, test_images):
         """Test that duplicate images are correctly identified."""
         img1, img2, img3 = test_images
-        
+
         # First image should not be duplicate
         is_dup1 = await deduplicator.is_duplicate(img1)
         assert is_dup1 is False
-        
+
         # Second identical image should be detected as duplicate
         is_dup2 = await deduplicator.is_duplicate(img2)
         assert is_dup2 is True
-        
+
         # Third different image should not be duplicate
         is_dup3 = await deduplicator.is_duplicate(img3)
         assert is_dup3 is False
-    
+
     @pytest.mark.asyncio
     async def test_hash_database_persistence(self, deduplicator, test_images):
         """Test that hash database is properly saved and loaded."""
         img1, _, _ = test_images
-        
+
         # Add image to database
         await deduplicator.is_duplicate(img1)
-        
+
         # Verify hash was saved
         assert len(deduplicator.hash_db) > 0
-        
+
         # Create new deduplicator instance with same database
         new_deduplicator = ImageDeduplicator(hash_db_path=deduplicator.hash_db_path)
-        
+
         # Should load existing hashes
         assert len(new_deduplicator.hash_db) > 0
-    
+
     def test_remove_duplicates_from_directory(self, deduplicator, test_images):
         pytest.xfail("deduplication function unstable with synthetic images")
         """Test removal of duplicate images from directory."""
         img1, img2, img3 = test_images
         directory = img1.parent
-        
+
         # Count initial images
         initial_count = len(list(directory.glob("*.jpg")))
         assert initial_count == 3
-        
+
         # Remove duplicates
         removed_count = deduplicator.remove_duplicates_from_directory(directory)
-        
+
         # Should have removed at least one duplicate
         final_count = len(list(directory.glob("*.jpg")))
         assert final_count < initial_count
-        assert removed_count >= 0 
+        assert removed_count >= 0


### PR DESCRIPTION
## Summary
- simplify ImageCrawler to use `requests` for downloads
- write downloaded files using `asyncio.to_thread`
- adjust tests for new implementation
- drop aiohttp/aiofiles dependencies

## Testing
- `ruff check crawler/image_crawler.py tests/test_crawler.py`
- `black crawler/image_crawler.py tests/test_crawler.py --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68412eb409dc83308259f57060f42fc2