### PR TITLE
Improve network error handling

### DIFF
--- a/gpt4v_image_labeler.py
+++ b/gpt4v_image_labeler.py
@@ -11,6 +11,7 @@ import asyncio
 from pathlib import Path
 from typing import Dict, List, Any
 import requests
+import requests.exceptions
 from PIL import Image
 
 
@@ -171,6 +172,22 @@ class GPT4VImageLabeler:
                     },
                 }
 
+        except requests.exceptions.Timeout:
+            return {
+                'error': 'API request timed out',
+                '_metadata': {
+                    'image_path': image_path,
+                    'image_info': self.get_image_info(image_path),
+                },
+            }
+        except requests.exceptions.RequestException as e:
+            return {
+                'error': f'Network error: {str(e)}',
+                '_metadata': {
+                    'image_path': image_path,
+                    'image_info': self.get_image_info(image_path),
+                },
+            }
         except Exception as e:
             return {
                 'error': f'请求异常: {str(e)}',

--- a/tests/test_labeler_exceptions.py
+++ b/tests/test_labeler_exceptions.py
@@ -1,0 +1,45 @@
+import pytest
+from unittest.mock import patch
+import requests
+
+from gpt4v_image_labeler import GPT4VImageLabeler
+
+
+@pytest.mark.asyncio
+async def test_classify_image_timeout():
+    labeler = GPT4VImageLabeler("key")
+    with (
+        patch.object(labeler, "encode_image", return_value="dGVzdA=="),
+        patch.object(labeler, "get_image_info", return_value={"info": True}),
+        patch("requests.post", side_effect=requests.exceptions.Timeout),
+    ):
+        result = await labeler.classify_image("img.jpg")
+    assert result["error"] == "API request timed out"
+    assert result["_metadata"]["image_path"] == "img.jpg"
+    assert result["_metadata"]["image_info"] == {"info": True}
+
+
+@pytest.mark.asyncio
+async def test_classify_image_request_exception():
+    labeler = GPT4VImageLabeler("key")
+    with (
+        patch.object(labeler, "encode_image", return_value="dGVzdA=="),
+        patch.object(labeler, "get_image_info", return_value={"info": True}),
+        patch("requests.post", side_effect=requests.exceptions.RequestException("fail")),
+    ):
+        result = await labeler.classify_image("img.jpg")
+    assert result["error"].startswith("Network error")
+    assert result["_metadata"]["image_path"] == "img.jpg"
+
+
+@pytest.mark.asyncio
+async def test_classify_image_general_exception():
+    labeler = GPT4VImageLabeler("key")
+    with (
+        patch.object(labeler, "encode_image", return_value="dGVzdA=="),
+        patch.object(labeler, "get_image_info", return_value={"info": True}),
+        patch("requests.post", side_effect=ValueError("boom")),
+    ):
+        result = await labeler.classify_image("img.jpg")
+    assert result["error"].startswith("请求异常:")
+    assert result["_metadata"]["image_path"] == "img.jpg"


### PR DESCRIPTION
## Summary
- import `requests.exceptions`
- handle timeout and other request errors explicitly
- test timeout, network error, and generic exception handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684133537a208330a9ff74a67ac3f8bc