### PR TITLE
Replace asyncio timestamps with UTC ISO format

### DIFF
--- a/gpt4v_image_labeler.py
+++ b/gpt4v_image_labeler.py
@@ -8,8 +8,9 @@ import os
 import json
 import base64
 import asyncio
+from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Any
+from typing import Any, Dict, List
 import requests
 import requests.exceptions
 from PIL import Image
@@ -143,7 +144,7 @@ class GPT4VImageLabeler:
                     classification_data['_metadata'] = {
                         'image_path': image_path,
                         'image_info': self.get_image_info(image_path),
-                        'classification_timestamp': asyncio.get_event_loop().time(),
+                        'classification_timestamp': datetime.utcnow().isoformat(),
                         'model_used': 'gpt-4o',
                         'api_response_tokens': result.get('usage', {}),
                         'purpose': 'OCR_DLP_performance_testing',

--- a/tests/test_integration_complete.py
+++ b/tests/test_integration_complete.py
@@ -5,6 +5,7 @@ Exercise the image search module (Serper) and the GPT-4V labeling workflow.
 """
 
 import asyncio
+from datetime import datetime
 import json
 import os
 import shutil
@@ -245,7 +246,7 @@ class TestIntegrationWorkflow:
             "document_quality": "清晰",
             "_metadata": {
                 "image_path": image_path,
-                "analysis_timestamp": asyncio.get_event_loop().time(),
+                "analysis_timestamp": datetime.utcnow().isoformat(),
                 "model_used": "gpt-4o",
                 "note": "Mock result due to API quota limits",
             },


### PR DESCRIPTION
## Summary
- use `datetime.utcnow().isoformat()` in labeler metadata
- update test fixture timestamp accordingly

## Testing
- `ruff check .` *(fails: Found 514 errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684141cb93c48330848c8e92153e19c5